### PR TITLE
improve error message for size parameter

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -231,7 +231,11 @@ end
 function prepare_output(plt::Plot)
     _before_layout_calcs(plt)
 
-    w, h = plt.attr[:size]
+    size = plt.attr[:size]
+    if length(size) != 2
+        throw(ArgumentError("size must be a tuple of length 2, for example size = (800,600)"))
+    end
+    w, h = size
     plt.layout.bbox = BoundingBox(0mm, 0mm, w * px, h * px)
 
     # One pass down and back up the tree to compute the minimum padding


### PR DESCRIPTION
If the size parameter of the plot is provided in the wrong format, provide a sensible error message. Current the behavior does not provide an indication on where the input problem is:

```julia
julia> using Plots

julia> plot(size=())
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: BoundsError: attempt to access Tuple{} at index [1]
Stacktrace:
  [1] indexed_iterate
    @ Base ./tuple.jl:92 [inlined]
  [2] indexed_iterate(t::Tuple{}, i::Int64)
    @ Base ./tuple.jl:92
  [3] prepare_output(plt::Plots.Plot{Plots.GRBackend})
    @ Plots ~/.julia/packages/Plots/sxUvK/src/plot.jl:234
  [4] display(::Plots.PlotsDisplay, plt::Plots.Plot{Plots.GRBackend})
    @ Plots ~/.julia/packages/Plots/sxUvK/src/output.jl:168
  [5] display(x::Any)
    @ Base.Multimedia ./multimedia.jl:340
  [6] #invokelatest#2
    @ Base ./essentials.jl:887 [inlined]
  [7] invokelatest
    @ Base ./essentials.jl:884 [inlined]
  [8] print_response(errio::IO, response::Any, show_value::Bool, have_color::Bool, specialdisplay::Union{…})
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:315
  [9] (::REPL.var"#57#58"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:284
 [10] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [11] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:282
 [12] (::REPL.var"#do_respond#80"{…})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:911
 [13] #invokelatest#2
    @ Base ./essentials.jl:887 [inlined]
 [14] invokelatest
    @ Base ./essentials.jl:884 [inlined]
 [15] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/LineEdit.jl:2656
 [16] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1312
 [17] (::REPL.var"#62#68"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.10.0-beta3+0.x64.linux.gnu/share/julia/stdlib/v1.10/REPL/src/REPL.jl:386
Some type information was truncated. Use `show(err)` to see complete types.
```
which when in the middle of a larger script can be really hard to track, as the error only manifest when the figure is being shown or saved. 

With this change, we get:

```julia
julia> plot(size=())
Error showing value of type Plots.Plot{Plots.GRBackend}:
ERROR: ArgumentError: size must be a tuple of length 2
Stacktrace:
```

and

```julia
julia> plt = plot(size = ());

julia> savefig(plt, "teste.png")
ERROR: ArgumentError: size must be a tuple of length 2
```

Which are much more clear.

## Description

## Attribution
- [ ] I am listed in [.zenodo.json](https://github.com/JuliaPlots/Plots.jl/blob/2463eb9f8065c52ed8314f6e541664c5b9db88d2/.zenodo.json) (see https://github.com/JuliaPlots/Plots.jl/issues/3503)

## Things to consider
- [ ] Does it work on log scales?
- [ ] Does it work in layouts?
- [ ] Does it work in recipes?
- [ ] Does it work with multiple series in one call?
- [ ] PR includes or updates tests?
- [ ] PR includes or updates documentation?
